### PR TITLE
Update the find public IP command

### DIFF
--- a/Labs/1.01.b - PART II - Connecting to K8s.md
+++ b/Labs/1.01.b - PART II - Connecting to K8s.md
@@ -54,8 +54,8 @@ Here is how this works:
 Find your public DC/OS agent IP (make sure to have jq installed - on Mac "brew install jq")
 
 ```
-for id in $(dcos node --json | jq --raw-output '.[] | select(.attributes.public_ip == "true") | .id'); \
-do dcos node ssh --user centos --option StrictHostKeyChecking=no --option LogLevel=quiet --master-proxy --mesos-id=$id "curl -s ifconfig.co" ; done 2>/dev/null
+for id in $(dcos node --json | jq --raw-output '.[] | select(.attributes.public_ip == "true") | .id'); do dcos node ssh --option StrictHostKeyChecking=no --option LogLevel=quiet --master-proxy --mesos-id=$id "curl -s ifconfig.co" ; done 2>/dev/null
+
 ```
 When multiple public DC/OS are deployed another option to find the IPs would be to use a script like the following:
 


### PR DESCRIPTION
Remove the username centos and use the command to find the public ip from the 1.11 docs.  tested 8/1